### PR TITLE
Fix Dependabot alerts: bump astro and @astrojs/rss

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
         "astro": "astro"
     },
     "dependencies": {
-        "@astrojs/mdx": "^1.1.5",
-        "@astrojs/rss": "^3.0.0",
+        "@astrojs/mdx": "^3.1.9",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/tailwind": "^5.1.5",
         "@iconify-json/fa-brands": "^1.2.1",
         "@iconify-json/fa-solid": "^1.2.1",
         "@tailwindcss/typography": "^0.5.16",
         "@types/canvas-confetti": "^1.9.0",
-        "astro": "^3.6.5",
+        "astro": "^4.16.19",
         "astro-icon": "^1.1.5",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.5.1",


### PR DESCRIPTION
## Summary
- Bumps `astro` from `^3.6.5` to `^4.16.19` (satisfies the required `>=4.16.17`), resolving CVE-2024-56159, CVE-2025-64764, CVE-2026-50146, CVE-2026-54299, CVE-2025-64757, and other alerts tied to astro < 4.16.17.
- Bumps `@astrojs/rss` from `^3.0.0` to `^4.0.19`, resolving CVE-2026-59728.
- Bumps `@astrojs/mdx` from `^1.1.5` to `^3.1.9` as a required companion change — the old version's peer dependency only supports `astro ^3`, so it would break the build under astro 4. `@astrojs/tailwind@^5.1.5` already supports `astro ^4`, so no change was needed there.

## Test plan
- [x] `npm install astro@^4.16.19 @astrojs/rss@^4.0.19 @astrojs/mdx@^3.1.9`
- [x] `npm run build` completes successfully, generating all 19 pages including `/feed.xml` (the RSS feed)
- [x] `npm audit` no longer reports the astro < 4.16.17 or @astrojs/rss < 4.0.19 alerts

Note: `npm audit` still reports unrelated, newer astro advisories that require an astro 7 major upgrade (a much larger breaking change not covered by this PR's scope of clearing the two specified Dependabot alerts).